### PR TITLE
59-SL Make upload image for event creation functional

### DIFF
--- a/src/components/CommunitiesComponents/CreateCommuniti3/CreateCommuniti3.jsx
+++ b/src/components/CommunitiesComponents/CreateCommuniti3/CreateCommuniti3.jsx
@@ -70,10 +70,10 @@ function CreateCommuniti3({ image, setImage, handleBack, handleNext }) {
                     className="create-communiti3__custom-file-input"
                   >
                     <img src={chooseFile} alt="Choose File Icon" />
+                    <p className="create-communiti3__container-input-text">
+                      drag and drop file or <span> choose file</span>
+                    </p>
                   </label>
-                  <p className="create-communiti3__container-input-text">
-                    drag and drop file or <span> choose file</span>
-                  </p>
                 </>
               )}
             </div>

--- a/src/components/CommunitiesComponents/CreateCommuniti3/CreateCommuniti3.scss
+++ b/src/components/CommunitiesComponents/CreateCommuniti3/CreateCommuniti3.scss
@@ -2,6 +2,21 @@
 @use "../../../styles/variables" as *;
 @use "../../../styles/typography" as *;
 
+.create-communiti3 {
+  &__custom-file-input {
+    height: 100%;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+    text-align: center;
+
+    img {
+      height: 66px;
+    }
+  }
+}
+
 .create-communiti3__container {
   @include Laptop {
     display: flex;
@@ -131,6 +146,6 @@
   }
 
   &-preview {
-    width: 40%;
+    height: 100%;
   }
 }

--- a/src/components/CreateEventModal/CreateEventModal.jsx
+++ b/src/components/CreateEventModal/CreateEventModal.jsx
@@ -305,10 +305,10 @@ function CreateEventModal({ setEventsOverlay }) {
                           className="create-communiti3__custom-file-input"
                         >
                           <img src={chooseFile} alt="Choose File Icon" />
+                          <p className="create-communiti3__container-input-text event-overlay__text ">
+                            drag and drop file or <span> choose file</span>
+                          </p>
                         </label>
-                        <p className="create-communiti3__container-input-text event-overlay__text ">
-                          drag and drop file or <span> choose file</span>
-                        </p>
                       </>
                     )}
                   </div>

--- a/src/components/CreateEventModal/CreateEventModal.scss
+++ b/src/components/CreateEventModal/CreateEventModal.scss
@@ -28,19 +28,6 @@
     gap: 2.2vw;
     display: flex;
 
-    .create-communiti3__custom-file-input {
-      height: 100%;
-      width: 100%;
-      display: flex;
-      justify-content: center;
-      flex-direction: column;
-
-      img {
-        height: 66px;
-        margin-top: 15px;
-        margin-bottom: -15px;
-      }
-    }
   }
 
   &__input {

--- a/src/components/CreateEventModal/CreateEventModal.scss
+++ b/src/components/CreateEventModal/CreateEventModal.scss
@@ -27,6 +27,20 @@
     flex-direction: column;
     gap: 2.2vw;
     display: flex;
+
+    .create-communiti3__custom-file-input {
+      height: 100%;
+      width: 100%;
+      display: flex;
+      justify-content: center;
+      flex-direction: column;
+
+      img {
+        height: 66px;
+        margin-top: 15px;
+        margin-bottom: -15px;
+      }
+    }
   }
 
   &__input {
@@ -170,6 +184,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+    margin-top: 80px;
   }
 
   &__button {


### PR DESCRIPTION
## Describe your changes
- Moved "drag and drop file or choose file" paragraph into label tag for image input field on both CreateCommuniti3 and CreateEventModal components
- Expanded clickable area of image input region by making label 100% height and width + flexbox styling in create-communiti3__custom-file-input class in CreateCommuniti3.scss (also affects styling for matching classNames in CreateEventModal)
- Made preview image height 100% for after user uploads image file

## Issue ticket number and link
[CL2-59 Make upload image for event creation functional](https://makeitmvp.atlassian.net/browse/CL2-59?atlOrigin=eyJpIjoiMjVmOWRlODkwOTgzNDg3OWIyYmM2ZTc2NzRhZDNlOTkiLCJwIjoiaiJ9) (subtask of [CL2-57](https://makeitmvp.atlassian.net/browse/CL2-57?atlOrigin=eyJpIjoiMDAxNjM1OWI3ZDc2NDc2ZGExODczNTAxNWExZDFhMTMiLCJwIjoiaiJ9))

## Checklist before requesting a review
- [x] I have performed a self-review of my code