### PR TITLE
60-SL Make upload image event field required

### DIFF
--- a/src/components/CommunitiesComponents/CreateCommuniti3/CreateCommuniti3.jsx
+++ b/src/components/CommunitiesComponents/CreateCommuniti3/CreateCommuniti3.jsx
@@ -45,7 +45,7 @@ function CreateCommuniti3({ image, setImage, handleBack, handleNext }) {
               className="create-communiti3__container-label"
               htmlFor="communiti-icon"
             >
-              {image ? "Upload complete!" : "Upload a Communiti image"}
+              {image ? "Upload complete!" : "Upload a Communiti image*"}
             </label>
             <div className="create-communiti3__container-input-container">
               {image ? (
@@ -64,6 +64,7 @@ function CreateCommuniti3({ image, setImage, handleBack, handleNext }) {
                     name="communiti-icon"
                     className="create-communiti3__container-input visually-hidden"
                     onChange={handleFileInputChange}
+                    required
                   />
                   <label
                     htmlFor="communiti-icon"

--- a/src/components/CreateEventModal/CreateEventModal.jsx
+++ b/src/components/CreateEventModal/CreateEventModal.jsx
@@ -278,7 +278,7 @@ function CreateEventModal({ setEventsOverlay }) {
                     className="create-communiti3__container-label event-overlay__picture-title"
                     htmlFor="communiti-icon"
                   >
-                    {image ? "Upload complete!" : "Upload a Thumbnail Image"}
+                    {image ? "Upload complete!" : "Upload a Thumbnail Image*"}
                   </label>
                   <div className="create-communiti3__container-input-container">
                     {image ? (
@@ -299,6 +299,7 @@ function CreateEventModal({ setEventsOverlay }) {
                           name="communiti-icon"
                           className="create-communiti3__container-input visually-hidden"
                           onChange={handleFileInputChange}
+                          required
                         />
                         <label
                           htmlFor="communiti-icon"


### PR DESCRIPTION
## Describe your changes
- Added required attribute to image input fields for CreateEventModal and CreateCommuniti3 components
- Added asterisk to "Upload a Thumbnail Image" label (unclear why existing code has 2 labels for communiti-icon input field — this will cause accessibility issues for screen readers in Firefox and Safari)

## Issue ticket number and link
[CL2-60 Make upload image in event creation a mandatory field](https://makeitmvp.atlassian.net/browse/CL2-60?atlOrigin=eyJpIjoiZjVjODhiZjQxNDg4NGViMWFjNjU5NjMzYmJkOGIzZmYiLCJwIjoiaiJ9) (subtask of [CL2-57](https://makeitmvp.atlassian.net/browse/CL2-57?atlOrigin=eyJpIjoiMDAxNjM1OWI3ZDc2NDc2ZGExODczNTAxNWExZDFhMTMiLCJwIjoiaiJ9))

## Checklist before requesting a review
- [x] I have performed a self-review of my code