### PR TITLE
63-SL Make events created populate under events tabs

### DIFF
--- a/src/components/EventsInfo/EventsInfo.jsx
+++ b/src/components/EventsInfo/EventsInfo.jsx
@@ -1,8 +1,8 @@
 import "./EventsInfo.scss";
 import EditIcon from "../../assets/images/EditIconWhite.svg";
 import { useState, useEffect } from "react";
-import { db } from "../../Firebase/FirebaseConfig";
-import { collection, getDocs, doc, query, getDoc } from "firebase/firestore";
+// import { db } from "../../Firebase/FirebaseConfig";
+// import { collection, getDocs, doc, query, getDoc } from "firebase/firestore";
 import data from "../../data.json";
 
 function EventsInfo({ communityId }) {

--- a/src/components/EventsInfo/EventsInfo.jsx
+++ b/src/components/EventsInfo/EventsInfo.jsx
@@ -3,65 +3,78 @@ import EditIcon from "../../assets/images/EditIconWhite.svg";
 import { useState, useEffect } from "react";
 import { db } from "../../Firebase/FirebaseConfig";
 import { collection, getDocs, doc, query, getDoc } from "firebase/firestore";
+import data from "../../data.json";
 
 function EventsInfo({ communityId }) {
   const [events, setEvents] = useState([]);
   const [communityInfo, setCommunityInfo] = useState(null);
 
+  // useEffect(() => {
+  //   const fetchCommunityData = async () => {
+  //     try {
+  //       if (communityId) {
+  //         const communityRef = doc(collection(db, "Communities"), communityId);
+  //         const communityDoc = await getDoc(communityRef);
+
+  //         if (communityDoc.exists()) {
+  //           const communityData = communityDoc.data();
+  //           setCommunityInfo(communityData);
+  //         }
+  //       }
+  //     } catch (error) {
+  //       console.error("Error fetching community details:", error);
+  //     }
+  //   };
+
+  //   fetchCommunityData();
+  // }, [communityId]);
+
   useEffect(() => {
-    const fetchCommunityData = async () => {
-      try {
-        if (communityId) {
-          const communityRef = doc(collection(db, "Communities"), communityId);
-          const communityDoc = await getDoc(communityRef);
-
-          if (communityDoc.exists()) {
-            const communityData = communityDoc.data();
-            setCommunityInfo(communityData);
-          }
-        }
-      } catch (error) {
-        console.error("Error fetching community details:", error);
-      }
-    };
-
-    fetchCommunityData();
-  }, [communityId]);
+    let community = data.communities.filter(c => {return c.id === communityId});
+    setCommunityInfo(community[0]);
+  },[]);
+  console.log(communityInfo);
 
   useEffect(() => {
-    const fetchCommunityEventsData = async () => {
-      try {
-        // Proceed only if communityInfo is available
-        if (communityInfo) {
-          const eventsQuery = query(
-            collection(db, "Communities", communityId, "Events")
-          );
-          const eventsSnapshot = await getDocs(eventsQuery);
-          const eventsData = [];
+    let events = data.events;
+    setEvents([events[0]]);
+  },[]);
+  console.log(events);
 
-          eventsSnapshot.forEach((doc) => {
-            const { title } = doc.data();
-            const { description } = doc.data();
-            const { eventImage } = doc.data();
-            const { startTime } = doc.data();
+  // useEffect(() => {
+  //   const fetchCommunityEventsData = async () => {
+  //     try {
+  //       // Proceed only if communityInfo is available
+  //       if (communityInfo) {
+  //         const eventsQuery = query(
+  //           collection(db, "Communities", communityId, "Events")
+  //         );
+  //         const eventsSnapshot = await getDocs(eventsQuery);
+  //         const eventsData = [];
 
-            eventsData.push({
-              title,
-              description,
-              eventImage,
-              startTime,
-            });
-          });
+  //         eventsSnapshot.forEach((doc) => {
+  //           const { title } = doc.data();
+  //           const { description } = doc.data();
+  //           const { eventImage } = doc.data();
+  //           const { startTime } = doc.data();
 
-          setEvents(eventsData);
-        }
-      } catch (error) {
-        console.error("Error fetching announcements:", error);
-      }
-    };
+  //           eventsData.push({
+  //             title,
+  //             description,
+  //             eventImage,
+  //             startTime,
+  //           });
+  //         });
 
-    fetchCommunityEventsData();
-  }, [communityInfo, communityId]);
+  //         setEvents(eventsData);
+  //       }
+  //     } catch (error) {
+  //       console.error("Error fetching announcements:", error);
+  //     }
+  //   };
+
+  //   fetchCommunityEventsData();
+  // }, [communityInfo, communityId]);
 
   const formatDate = (timestamp) => {
     const eventDate = new Date(timestamp);

--- a/src/components/EventsInfo/EventsInfo.jsx
+++ b/src/components/EventsInfo/EventsInfo.jsx
@@ -36,10 +36,8 @@ function EventsInfo({ communityId }) {
   console.log(communityInfo);
 
   useEffect(() => {
-    let events = data.events;
-    setEvents([events[0]]);
+    setEvents(data.events);
   },[]);
-  console.log(events);
 
   // useEffect(() => {
   //   const fetchCommunityEventsData = async () => {

--- a/src/components/EventsInfoPublic/EventsInfo.jsx
+++ b/src/components/EventsInfoPublic/EventsInfo.jsx
@@ -4,6 +4,7 @@ import PlusIcon from "../../assets/images/PlusIcon-Black.svg";
 import { useState, useEffect } from "react";
 import { db } from "../../Firebase/FirebaseConfig";
 import { collection, getDocs, doc, query, getDoc } from "firebase/firestore";
+import data from "../../data.json";
 
 function EventsInfo({ communityId }) {
   const [userAttending, setUserAttending] = useState(false);
@@ -11,59 +12,66 @@ function EventsInfo({ communityId }) {
   const [communityInfo, setCommunityInfo] = useState(null);
 
   useEffect(() => {
-    const fetchCommunityData = async () => {
-      try {
-        if (communityId) {
-          const communityRef = doc(collection(db, "Communities"), communityId);
-          const communityDoc = await getDoc(communityRef);
+    let events = data.events;
+    setEvents([events[1]]);
+  },[]);
+  console.log(events);
 
-          if (communityDoc.exists()) {
-            const communityData = communityDoc.data();
-            setCommunityInfo(communityData);
-          }
-        }
-      } catch (error) {
-        console.error("Error fetching community details:", error);
-      }
-    };
 
-    fetchCommunityData();
-  }, [communityId]);
+  // useEffect(() => {
+  //   const fetchCommunityData = async () => {
+  //     try {
+  //       if (communityId) {
+  //         const communityRef = doc(collection(db, "Communities"), communityId);
+  //         const communityDoc = await getDoc(communityRef);
 
-  useEffect(() => {
-    const fetchCommunityEventsData = async () => {
-      try {
-        // Proceed only if communityInfo is available
-        if (communityInfo) {
-          const eventsQuery = query(
-            collection(db, "Communities", communityId, "Events")
-          );
-          const eventsSnapshot = await getDocs(eventsQuery);
-          const eventsData = [];
+  //         if (communityDoc.exists()) {
+  //           const communityData = communityDoc.data();
+  //           setCommunityInfo(communityData);
+  //         }
+  //       }
+  //     } catch (error) {
+  //       console.error("Error fetching community details:", error);
+  //     }
+  //   };
 
-          eventsSnapshot.forEach((doc) => {
-            const { title } = doc.data();
-            const { description } = doc.data();
-            const { eventImage } = doc.data();
-            const { startTime } = doc.data();
+  //   fetchCommunityData();
+  // }, [communityId]);
 
-            eventsData.push({
-              title,
-              description,
-              eventImage,
-              startTime,
-            });
-          });
+  // useEffect(() => {
+  //   const fetchCommunityEventsData = async () => {
+  //     try {
+  //       // Proceed only if communityInfo is available
+  //       if (communityInfo) {
+  //         const eventsQuery = query(
+  //           collection(db, "Communities", communityId, "Events")
+  //         );
+  //         const eventsSnapshot = await getDocs(eventsQuery);
+  //         const eventsData = [];
 
-          setEvents(eventsData);
-        }
-      } catch (error) {
-        console.error("Error fetching announcements:", error);
-      }
-    };
+  //         eventsSnapshot.forEach((doc) => {
+  //           const { title } = doc.data();
+  //           const { description } = doc.data();
+  //           const { eventImage } = doc.data();
+  //           const { startTime } = doc.data();
 
-    fetchCommunityEventsData();
-  }, [communityInfo, communityId]);
+  //           eventsData.push({
+  //             title,
+  //             description,
+  //             eventImage,
+  //             startTime,
+  //           });
+  //         });
+
+  //         setEvents(eventsData);
+  //       }
+  //     } catch (error) {
+  //       console.error("Error fetching announcements:", error);
+  //     }
+  //   };
+
+  //   fetchCommunityEventsData();
+  // }, [communityInfo, communityId]);
 
   const formatDate = (timestamp) => {
     const eventDate = new Date(timestamp);

--- a/src/components/EventsInfoPublic/EventsInfo.jsx
+++ b/src/components/EventsInfoPublic/EventsInfo.jsx
@@ -2,8 +2,8 @@ import "./EventsInfo.scss";
 import CheckMark from "../../assets/images/CheckMark-Black.svg";
 import PlusIcon from "../../assets/images/PlusIcon-Black.svg";
 import { useState, useEffect } from "react";
-import { db } from "../../Firebase/FirebaseConfig";
-import { collection, getDocs, doc, query, getDoc } from "firebase/firestore";
+// import { db } from "../../Firebase/FirebaseConfig";
+// import { collection, getDocs, doc, query, getDoc } from "firebase/firestore";
 import data from "../../data.json";
 
 function EventsInfo({ communityId }) {

--- a/src/components/EventsTab/EventsTab.jsx
+++ b/src/components/EventsTab/EventsTab.jsx
@@ -1,8 +1,6 @@
 import "./EventsTab.scss";
-// import Events from "../Events/Event";
 import { useParams } from "react-router-dom";
 import EventsInfo from "../EventsInfo/EventsInfo";
-import data from "../../data.json";
 
 function EventsTab({ communityData, setEventsOverlay, events }) {
   const { id } = useParams();

--- a/src/components/EventsTab/EventsTab.jsx
+++ b/src/components/EventsTab/EventsTab.jsx
@@ -1,7 +1,12 @@
 import "./EventsTab.scss";
-import Events from "../Events/Event";
+// import Events from "../Events/Event";
+import { useParams } from "react-router-dom";
+import EventsInfo from "../EventsInfo/EventsInfo";
+import data from "../../data.json";
 
 function EventsTab({ communityData, setEventsOverlay, events }) {
+  const { id } = useParams();
+
   function noEvents() {
     return (
       <div className="events-tab__none">
@@ -41,7 +46,7 @@ function EventsTab({ communityData, setEventsOverlay, events }) {
       <div className="events-tab-">
         {events.length === 0 ? noEvents() : someEvents()}
       </div>
-      <Events communityData={communityData} />
+      <EventsInfo communityId={id} />;
     </section>
   );
 }

--- a/src/components/EventsTabPublic/EventsTabPublic.jsx
+++ b/src/components/EventsTabPublic/EventsTabPublic.jsx
@@ -1,11 +1,10 @@
 import "./EventsTabPublic.scss";
 import { useState, useEffect } from "react";
-import { collection, getDocs, doc, query, getDoc } from "firebase/firestore";
-import { db } from "../../Firebase/FirebaseConfig";
+// import { collection, getDocs, doc, query, getDoc } from "firebase/firestore";
+// import { db } from "../../Firebase/FirebaseConfig";
 import { useParams } from "react-router-dom";
 // import Events from "../Events/Event";
-import EventsInfo from "../EventsInfo/EventsInfo";
-import data from "../../data.json";
+import EventsInfo from "../EventsInfoPublic/EventsInfo";
 
 
 function EventsTab({ communityData }) {

--- a/src/components/EventsTabPublic/EventsTabPublic.jsx
+++ b/src/components/EventsTabPublic/EventsTabPublic.jsx
@@ -3,39 +3,43 @@ import { useState, useEffect } from "react";
 import { collection, getDocs, doc, query, getDoc } from "firebase/firestore";
 import { db } from "../../Firebase/FirebaseConfig";
 import { useParams } from "react-router-dom";
-import Events from "../Events/Event";
+// import Events from "../Events/Event";
+import EventsInfo from "../EventsInfo/EventsInfo";
+import data from "../../data.json";
+
 
 function EventsTab({ communityData }) {
   const [events, setEvents] = useState([]);
   const [hasEvents, setHasEvents] = useState(false);
   const { id } = useParams();
 
-  useEffect(() => {
-    const fetchCommunityEventsData = async () => {
-      try {
-        const communityRef = doc(collection(db, "Communities"), id);
-        const communityDoc = await getDoc(communityRef);
+  // useEffect(() => {
+  //   const fetchCommunityEventsData = async () => {
+  //     try {
+  //       const communityRef = doc(collection(db, "Communities"), id);
+  //       const communityDoc = await getDoc(communityRef);
 
-        if (communityDoc.exists()) {
-          const eventsQuery = query(collection(communityRef, "Events"));
-          const eventsSnapshot = await getDocs(eventsQuery);
+  //       if (communityDoc.exists()) {
+  //         const eventsQuery = query(collection(communityRef, "Events"));
+  //         const eventsSnapshot = await getDocs(eventsQuery);
 
-          // Check if there are any events
-          setHasEvents(!eventsSnapshot.empty);
-        }
-      } catch (error) {
-        console.error("Error fetching events:", error);
-      }
-    };
+  //         // Check if there are any events
+  //         setHasEvents(!eventsSnapshot.empty);
+  //       }
+  //     } catch (error) {
+  //       console.error("Error fetching events:", error);
+  //     }
+  //   };
 
-    fetchCommunityEventsData();
-  }, [id]);
+  //   fetchCommunityEventsData();
+  // }, [id]);
+
 
   function noEvents() {
     return (
       <div className="events-tab-public__none">
         <p className="events-tab-public__none-writing">
-          Oops! No Events Events will appear here when they are available. Get
+          Oops! No events found for this community. Events will appear here when they are available. Get
           ready for something amazing!
         </p>
       </div>
@@ -43,16 +47,19 @@ function EventsTab({ communityData }) {
   }
 
   function renderEvents() {
-    if (!hasEvents) {
-      return noEvents();
-    } else {
-      return <Events events={events} communityData={communityData} />;
-    }
+    // if (!hasEvents) {
+    //   return noEvents();
+    // } else {
+    //   return <Events events={events} communityData={communityData} />;
+    // }
+    // return <Events events={events} communityData={communityData} />;
+    return <EventsInfo communityId={id} />;
   }
 
   return (
-    <section className="events-tab-public-background">
-      <div className="events-tab-public">{renderEvents()}</div>
+    // <section className="events-tab-public-background">
+    <section className="events-tab-public__section">
+      {renderEvents()}
     </section>
   );
 }

--- a/src/components/EventsTabPublic/EventsTabPublic.scss
+++ b/src/components/EventsTabPublic/EventsTabPublic.scss
@@ -47,5 +47,19 @@ $mockup-light-blue: #e1f0fb;
         width: 26vw;
       }
     }
+
+
   }
+      &__section {
+      background-color: rgba($MVP-Light-Blue, 0.2);
+      border-radius: 0.5vw;
+      border: 0.2vw solid #000;
+      width: 78.5vw;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      color: pink;
+          padding: 4vw 3vw;
+    }
 }

--- a/src/components/EventsTabPublic/EventsTabPublic.scss
+++ b/src/components/EventsTabPublic/EventsTabPublic.scss
@@ -59,7 +59,6 @@ $mockup-light-blue: #e1f0fb;
       flex-direction: column;
       justify-content: center;
       align-items: center;
-      color: pink;
-          padding: 4vw 3vw;
+      padding: 4vw 3vw;
     }
 }

--- a/src/data.json
+++ b/src/data.json
@@ -113,15 +113,15 @@
   "communities": [
     {
       "id": "community1_uuid",
-      "communityImage": "https://firebasestorage.googleapis.com/v0/b/communiti-630fc.appspot.com/o/event_thumbnails%2FIMG_1162.jpeg?alt=media&token=c2e2c6c3-ff56-48ad-b6c6-d97b39bbca87",
-      "created": "2024-02-08T12:45:00Z",
-      "createdBy": "user1_uuid",
-      "description": "Community for software developers.",
-      "location": [
+      "CommunityImage": "https://firebasestorage.googleapis.com/v0/b/communiti-630fc.appspot.com/o/event_thumbnails%2FIMG_1162.jpeg?alt=media&token=c2e2c6c3-ff56-48ad-b6c6-d97b39bbca87",
+      "Created": "2024-02-08T12:45:00Z",
+      "CreatedBy": "user1_uuid",
+      "Description": "Community for software developers.",
+      "Location": [
         "City A"
       ],
-      "name": "DevCommunity",
-      "announcements": [
+      "Name": "DevCommunity",
+      "Announcements": [
         {
           "id": "announcement1_uuid",
           "message": "Welcome to DevCommunity!",
@@ -129,19 +129,19 @@
           "createdBy": "user1_uuid"
         }
       ],
-      "newsLetters": []
+      "NewsLetters": []
     },
     {
       "id": "community2_uuid",
-      "communityImage": "https://firebasestorage.googleapis.com/v0/b/communiti-630fc.appspot.com/o/community_images%2FIMG_1113.jpeg?alt=media&token=f047e3f1-ae81-45a5-8e2f-9fe65eee57a3",
-      "created": "2024-02-08T13:30:00Z",
-      "createdBy": "user2_uuid",
-      "description": "Community for sales and marketing professionals.",
-      "location": [
+      "CommunityImage": "https://firebasestorage.googleapis.com/v0/b/communiti-630fc.appspot.com/o/community_images%2FIMG_1113.jpeg?alt=media&token=f047e3f1-ae81-45a5-8e2f-9fe65eee57a3",
+      "Created": "2024-02-08T13:30:00Z",
+      "CreatedBy": "user2_uuid",
+      "Description": "Community for sales and marketing professionals.",
+      "Location": [
         "City B"
       ],
-      "name": "SalesPros",
-      "announcements": [
+      "Name": "SalesPros",
+      "Announcements": [
         {
           "id": "announcement2_uuid",
           "message": "Welcome to SalesPros!",
@@ -149,7 +149,7 @@
           "createdBy": "user2_uuid"
         }
       ],
-      "newsLetters": []
+      "NewsLetters": []
     }
   ],
   "events": [

--- a/src/data.json
+++ b/src/data.json
@@ -1,0 +1,198 @@
+{
+  "users": [
+    {
+      "id": "user1_uuid",
+      "displayName": "User 1",
+      "email": "user1@example.com",
+      "password": "hellohello",
+      "profilePhoto": "https://images.unsplash.com/photo-1523480717984-24cba35ae1ef?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+      "createdAt": "2024-02-08T12:00:00Z",
+      "fullName": "User One",
+      "discipline": "Engineering",
+      "expertise": "Software Development",
+      "industry": "Technology",
+      "bio": "Passionate about coding and technology.",
+      "mentor": true,
+      "mentee": false,
+      "location": "City A",
+      "phoneNumber": "+1234567890",
+      "appointments": 0,
+      "chats": 0,
+      "connections": 0,
+      "communitiesJoined": [
+        "community2_uuid"
+      ],
+      "communitiesManaged": [
+        "community1_uuid"
+      ]
+    },
+    {
+      "id": "user2_uuid",
+      "displayName": "User 2",
+      "email": "user2@example.com",
+      "password": "hellohello",
+      "profilePhoto": "https://images.unsplash.com/photo-1559624989-7b9303bd9792?q=80&w=1376&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+      "createdAt": "2024-02-08T12:30:00Z",
+      "fullName": "User Two",
+      "discipline": "Business",
+      "expertise": "Marketing",
+      "industry": "Sales",
+      "bio": "Driven marketer with a focus on sales strategies.",
+      "mentor": false,
+      "mentee": true,
+      "location": "City B",
+      "phoneNumber": "+9876543210",
+      "appointments": 0,
+      "chats": 0,
+      "connections": 0,
+      "communitiesJoined": [
+        "community1_uuid"
+      ],
+      "communitiesManaged": [
+        "community2_uuid"
+      ]
+    },
+    {
+      "id": "user3_uuid",
+      "displayName": "User 3",
+      "email": "user3@example.com",
+      "password": "hellohello",
+      "profilePhoto": "https://images.unsplash.com/photo-1555169062-013468b47731?q=80&w=987&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+      "createdAt": "2024-02-08T12:30:00Z",
+      "fullName": "User Three",
+      "discipline": "Business",
+      "expertise": "Marketing",
+      "industry": "Sales",
+      "bio": "Driven marketer with a focus on sales strategies.",
+      "mentor": false,
+      "mentee": true,
+      "location": "City C",
+      "phoneNumber": "+9876543210",
+      "appointments": 0,
+      "chats": 0,
+      "connections": 0,
+      "communitiesJoined": [
+        "community1_uuid",
+        "community2_uuid"
+      ],
+      "communitiesManaged": []
+    }
+  ],
+  "communityUserRelationships": [
+    {
+      "communityId": "community1_uuid",
+      "userId": "user1_uuid",
+      "managing": true
+    },
+    {
+      "communityId": "community2_uuid",
+      "userId": "user2_uuid",
+      "managing": true
+    },
+    {
+      "communityId": "community1_uuid",
+      "userId": "user2_uuid",
+      "managing": false
+    },
+    {
+      "communityId": "community2_uuid",
+      "userId": "user1_uuid",
+      "managing": false
+    },
+    {
+      "communityId": "community1_uuid",
+      "userId": "user3_uuid",
+      "managing": false
+    },
+        {
+      "communityId": "community2_uuid",
+      "userId": "user3_uuid",
+      "managing": false
+    }
+  ],
+  "communities": [
+    {
+      "id": "community1_uuid",
+      "communityImage": "https://firebasestorage.googleapis.com/v0/b/communiti-630fc.appspot.com/o/event_thumbnails%2FIMG_1162.jpeg?alt=media&token=c2e2c6c3-ff56-48ad-b6c6-d97b39bbca87",
+      "created": "2024-02-08T12:45:00Z",
+      "createdBy": "user1_uuid",
+      "description": "Community for software developers.",
+      "location": [
+        "City A"
+      ],
+      "name": "DevCommunity",
+      "announcements": [
+        {
+          "id": "announcement1_uuid",
+          "message": "Welcome to DevCommunity!",
+          "posted": "2024-02-08T13:00:00Z",
+          "createdBy": "user1_uuid"
+        }
+      ],
+      "newsLetters": []
+    },
+    {
+      "id": "community2_uuid",
+      "communityImage": "https://firebasestorage.googleapis.com/v0/b/communiti-630fc.appspot.com/o/community_images%2FIMG_1113.jpeg?alt=media&token=f047e3f1-ae81-45a5-8e2f-9fe65eee57a3",
+      "created": "2024-02-08T13:30:00Z",
+      "createdBy": "user2_uuid",
+      "description": "Community for sales and marketing professionals.",
+      "location": [
+        "City B"
+      ],
+      "name": "SalesPros",
+      "announcements": [
+        {
+          "id": "announcement2_uuid",
+          "message": "Welcome to SalesPros!",
+          "posted": "2024-02-08T14:00:00Z",
+          "createdBy": "user2_uuid"
+        }
+      ],
+      "newsLetters": []
+    }
+  ],
+  "events": [
+    {
+      "id": "event1_uuid",
+      "date": "2024-02-15",
+      "description": "Lorem ipsum dolor sit amet consectetur adipisicing elit. Unde perspiciatis eius vero atque beatae eos laudantium quis mollitia ipsam molestiae.",
+      "endTime": "2024-02-14T11:38:30.000Z",
+      "eventImage": "https://firebasestorage.googleapis.com/v0/b/communiti-630fc.appspot.com/o/event_thumbnails%2FIMG_1162.jpeg?alt=media&token=c2e2c6c3-ff56-48ad-b6c6-d97b39bbca87",
+      "locationType": "Venue",
+      "startTime": "2024-02-14T10:00:00.000Z",
+      "title": "How AI can help in Marketing123",
+      "timestamp": "2024-02-08T15:00:00Z",
+      "timezone": "America/Los_Angeles",
+      "venueAddress": "213 Seymour st., Denver",
+      "requiresApproval": false,
+      "organizedBy": {
+        "name": "Marina Reese",
+        "position": "Product Manager"
+      },
+      "communityInfo": "Communiti Group",
+      "community": "community1_uuid",
+      "venue": "Online"
+    },
+    {
+      "id": "event2_uuid",
+      "date": "2024-02-20",
+      "description": "Lorem ipsum dolor sit amet consectetur adipisicing elit. Unde perspiciatis eius vero atque beatae eos laudantium quis mollitia ipsam molestiae.",
+      "endTime": "2024-03-22T16:00:00.000Z",
+      "eventImage": "https://firebasestorage.googleapis.com/v0/b/communiti-630fc.appspot.com/o/community_images%2FIMG_1113.jpeg?alt=media&token=f047e3f1-ae81-45a5-8e2f-9fe65eee57a3",
+      "locationType": "In Person",
+      "startTime": "2024-03-22T14:30:00.000Z",
+      "title": "SalesPros Workshop",
+      "timestamp": "2024-02-05T14:00:00Z",
+      "timezone": "America/Los_Angeles",
+      "venueAddress": "213 Seymour st., Denver",
+      "requiresApproval": true,
+      "organizedBy": {
+        "name": "Marina Reese",
+        "position": "Product Manager"
+      },
+      "communityInfo": "SuperGroup",
+      "community": "community2_uuid"
+    }
+  ]
+}

--- a/src/pages/Communites/AdminCommunitiProfile/AdminCommunitiProfile.jsx
+++ b/src/pages/Communites/AdminCommunitiProfile/AdminCommunitiProfile.jsx
@@ -1,6 +1,6 @@
 import "./AdminCommunitiProfile.scss";
 import { useState, useEffect } from "react";
-import DashboardNavbar from "../../../components/DashboardNavbar/DashboardNavbar";
+// import DashboardNavbar from "../../../components/DashboardNavbar/DashboardNavbar";
 import back from "../../../assets/images/back.svg";
 import penAndPaper from "../../../assets/images/penAndPaper.svg";
 import location from "../../../assets/images/location.svg";
@@ -9,10 +9,11 @@ import AnnouncementsTab from "../../../components/AnnouncementsTab/Announcements
 import EventsTab from "../../../components/EventsTab/EventsTab";
 import MembersTab from "../../../components/MembersTab/MembersTab";
 import { useParams, useNavigate } from "react-router-dom";
-import { db } from "../../../Firebase/FirebaseConfig";
-import { collection, doc, getDoc, getDocs } from "firebase/firestore";
+// import { db } from "../../../Firebase/FirebaseConfig";
+// import { collection, doc, getDoc, getDocs } from "firebase/firestore";
 import AnnouncmentsOverlay from "../../../components/AnnouncementsOverlay/AnnouncementsOverlay";
 import EventsOverlay from "../../../components/CreateEventModal/CreateEventModal";
+import data from "../../../data.json";
 
 function AdminCommunitiProfile() {
   const { id } = useParams();
@@ -30,82 +31,91 @@ function AdminCommunitiProfile() {
   const [memberRoles, setMemberRoles] = useState([]);
   const [inviteLink, setInviteLink] = useState("");
 
+  // DUMMY DATA
   useEffect(() => {
-    const fetchCommunityData = async () => {
-      try {
-        if (id) {
-          const communityRef = doc(collection(db, "Communities"), id);
-          const communityDoc = await getDoc(communityRef);
+    let community = data.communities[1];
+    setCommunityData(community);
+    setAnnouncements(community.announcements || []);
+    setEvents(data.events || []);
+  },[]);
+  console.log(data.communities[1].Name);
 
-          if (communityDoc.exists()) {
-            const community = communityDoc.data();
-            setCommunityData(community);
-            setAnnouncements(community.announcements || []);
-            setEvents(community.events || []);
+  // useEffect(() => {
+  //   const fetchCommunityData = async () => {
+  //     try {
+  //       if (id) {
+  //         const communityRef = doc(collection(db, "Communities"), id);
+  //         const communityDoc = await getDoc(communityRef);
 
-            // Fetch the Members subcollection and count its documents
-            const membersCollectionRef = collection(
-              db,
-              `Communities/${id}/Members`
-            );
-            const membersSnapshot = await getDocs(membersCollectionRef);
-            const memberIds = membersSnapshot.docs.map((doc) => doc.id);
-            setMemberIds(memberIds);
-            setMemberCount(memberIds.length);
+  //         if (communityDoc.exists()) {
+  //           const community = communityDoc.data();
+  //           setCommunityData(community);
+  //           setAnnouncements(community.announcements || []);
+  //           setEvents(community.events || []);
 
-            const memberRoles = [];
-            for (const memberId of memberIds) {
-              const memberRef = doc(
-                collection(db, `Communities/${id}/Members`),
-                memberId
-              );
-              const memberDoc = await getDoc(memberRef);
-              if (memberDoc.exists()) {
-                const memberData = memberDoc.data();
-                const memberRole = {
-                  memberId,
-                  role: memberData.role || "New Member",
-                };
-                memberRoles.push(memberRole);
-              }
-            }
-            setMemberRoles(memberRoles);
-          } else {
-            console.log("No such document!");
-          }
-        }
-      } catch (error) {
-        console.error("Error fetching document: ", error);
-      }
-    };
+  //           // Fetch the Members subcollection and count its documents
+  //           const membersCollectionRef = collection(
+  //             db,
+  //             `Communities/${id}/Members`
+  //           );
+  //           const membersSnapshot = await getDocs(membersCollectionRef);
+  //           const memberIds = membersSnapshot.docs.map((doc) => doc.id);
+  //           setMemberIds(memberIds);
+  //           setMemberCount(memberIds.length);
 
-    fetchCommunityData();
-  }, [id]);
+  //           const memberRoles = [];
+  //           for (const memberId of memberIds) {
+  //             const memberRef = doc(
+  //               collection(db, `Communities/${id}/Members`),
+  //               memberId
+  //             );
+  //             const memberDoc = await getDoc(memberRef);
+  //             if (memberDoc.exists()) {
+  //               const memberData = memberDoc.data();
+  //               const memberRole = {
+  //                 memberId,
+  //                 role: memberData.role || "New Member",
+  //               };
+  //               memberRoles.push(memberRole);
+  //             }
+  //           }
+  //           setMemberRoles(memberRoles);
+  //         } else {
+  //           console.log("No such document!");
+  //         }
+  //       }
+  //     } catch (error) {
+  //       console.error("Error fetching document: ", error);
+  //     }
+  //   };
 
-  useEffect(() => {
-    const fetchCommunityData = async () => {
-      try {
-        if (id) {
-          const communityRef = doc(collection(db, "Communities"), id);
-          const communityDoc = await getDoc(communityRef);
+  //   fetchCommunityData();
+  // }, [id]);
 
-          if (communityDoc.exists()) {
-            const community = communityDoc.data();
+  // useEffect(() => {
+  //   const fetchCommunityData = async () => {
+  //     try {
+  //       if (id) {
+  //         const communityRef = doc(collection(db, "Communities"), id);
+  //         const communityDoc = await getDoc(communityRef);
 
-            // Create the invite link based on the community ID
-            const link = `https://communiti-630fc.web.app/communities/${id}`;
-            setInviteLink(link);
-          } else {
-            console.log("No such document!");
-          }
-        }
-      } catch (error) {
-        console.error("Error fetching document: ", error);
-      }
-    };
+  //         if (communityDoc.exists()) {
+  //           const community = communityDoc.data();
 
-    fetchCommunityData();
-  }, [id]);
+  //           // Create the invite link based on the community ID
+  //           const link = `https://communiti-630fc.web.app/communities/${id}`;
+  //           setInviteLink(link);
+  //         } else {
+  //           console.log("No such document!");
+  //         }
+  //       }
+  //     } catch (error) {
+  //       console.error("Error fetching document: ", error);
+  //     }
+  //   };
+
+  //   fetchCommunityData();
+  // }, [id]);
 
   const copyToClipboard = async () => {
     try {
@@ -152,7 +162,7 @@ function AdminCommunitiProfile() {
           communityData={communityData}
         />
       )}
-      <DashboardNavbar />
+      {/* <DashboardNavbar /> */}
       <main className="admin-communiti-profile">
         <section className="admin-communiti-profile__hero">
           <div

--- a/src/pages/CommunitiProfile/CommunitiProfile.jsx
+++ b/src/pages/CommunitiProfile/CommunitiProfile.jsx
@@ -6,6 +6,7 @@ import location from "../../assets/images/location.svg";
 import members from "../../assets/images/members.svg";
 import AnnouncementsTab from "../../components/AnnouncementsTabPublic/AnnouncementsTabPublic";
 import EventsTab from "../../components/EventsTabPublic/EventsTabPublic";
+import EventsInfo from "../../components/EventsInfo/EventsInfo";
 import MembersTab from "../../components/MembersTab/MembersTab";
 import { useParams } from "react-router-dom";
 // import { db, auth } from "../../Firebase/FirebaseConfig";
@@ -31,14 +32,17 @@ function CommunitiProfile() {
   const [memberIds, setMemberIds] = useState([]);
   const [memberRoles, setMemberRoles] = useState([]);
   const [isUserJoined, setIsUserJoined] = useState(false); // Define isUserJoined state
+  const [communityId, setCommunityId] = useState(null);
 
+  // DUMMY DATA
   useEffect(() => {
-    let community = data.communities.filter(c => {return c.id === communityId})[0];
+    let community = data.communities[0];
+    setCommunityId(community.id)
     setCommunityData(community);
     setAnnouncements(community.announcements || []);
-    setEvents(community.events || []);
+    setEvents(data.events || []);
   },[]);
-  console.log(communityInfo);
+  console.log(data.communities[0].Name);
 
   // useEffect(() => {
   //   const fetchCommunityData = async () => {
@@ -91,19 +95,19 @@ function CommunitiProfile() {
   //   fetchCommunityData();
   // }, [id]);
 
-  useEffect(() => {
-    const currentUser = auth.currentUser;
-    if (currentUser) {
-      const userId = currentUser.uid;
+  // useEffect(() => {
+  //   const currentUser = auth.currentUser;
+  //   if (currentUser) {
+  //     const userId = currentUser.uid;
+  //     setIsUserJoined(memberIds.includes(userId)); // Set the user's membership status
+  //   }
+  // }, [memberIds]); // Update isUserJoined when memberIds change
 
-
-      // Dummy data insert
-      userId = data.users[0].uid;
-
-
-      setIsUserJoined(memberIds.includes(userId)); // Set the user's membership status
-    }
-  }, [memberIds]); // Update isUserJoined when memberIds change
+  //   useEffect(() => {
+  //     // Dummy data insert
+  //     let userId = data.users[0].uid;
+  //     setIsUserJoined(memberIds.includes(userId)); // Set the user's membership status
+  // }, [memberIds]); // Update isUserJoined when memberIds change
 
   function handleTabChoice(choice) {
     switch (choice) {
@@ -127,38 +131,38 @@ function CommunitiProfile() {
     }
   }
 
-  const handleJoinCommunity = async () => {
-    const currentUser = auth.currentUser;
-    const communityId = id;
+  // const handleJoinCommunity = async () => {
+  //   const currentUser = auth.currentUser;
+  //   const communityId = id;
 
-    if (currentUser) {
-      const userId = currentUser.uid;
+  //   if (currentUser) {
+  //     const userId = currentUser.uid;
 
-      const memberRef = doc(db, `Communities/${communityId}/Members`, userId);
-      await setDoc(memberRef, { userId: userId, role: "Member" });
+  //     const memberRef = doc(db, `Communities/${communityId}/Members`, userId);
+  //     await setDoc(memberRef, { userId: userId, role: "Member" });
 
-      const userRef = doc(db, "Users", userId);
-      const userDoc = await getDoc(userRef);
-      if (userDoc.exists()) {
-        const userData = userDoc.data();
-        const communitiesJoined = userData.CommunitiesJoined || [];
+  //     const userRef = doc(db, "Users", userId);
+  //     const userDoc = await getDoc(userRef);
+  //     if (userDoc.exists()) {
+  //       const userData = userDoc.data();
+  //       const communitiesJoined = userData.CommunitiesJoined || [];
 
-        if (!communitiesJoined.includes(communityId)) {
-          const updatedCommunities = [...communitiesJoined, communityId];
-          await updateDoc(userRef, {
-            CommunitiesJoined: updatedCommunities,
-          });
-          console.log("Joined Community !");
-        } else {
-          console.log("User has already joined this community!");
-        }
-      } else {
-        console.log("User document does not exist.");
-      }
-    } else {
-      console.log("Please Login");
-    }
-  };
+  //       if (!communitiesJoined.includes(communityId)) {
+  //         const updatedCommunities = [...communitiesJoined, communityId];
+  //         await updateDoc(userRef, {
+  //           CommunitiesJoined: updatedCommunities,
+  //         });
+  //         console.log("Joined Community !");
+  //       } else {
+  //         console.log("User has already joined this community!");
+  //       }
+  //     } else {
+  //       console.log("User document does not exist.");
+  //     }
+  //   } else {
+  //     console.log("Please Login");
+  //   }
+  // };
 
   return (
     <>
@@ -169,7 +173,7 @@ function CommunitiProfile() {
             <div className="communiti-profile__button-container">
               <button
                 className="communiti-profile__button"
-                onClick={handleJoinCommunity}
+                // onClick={handleJoinCommunity}
               >
                 Join the Community
               </button>
@@ -263,13 +267,15 @@ function CommunitiProfile() {
                 </p>
               </div>
 
-              {showAnnouncements && (
+              {/* {showAnnouncements && (
                 <AnnouncementsTab
                   announcements={announcements}
                   communityData={communityData}
                 />
-              )}
-              {showEvents && <EventsTab events={events} />}
+              )} */}
+              {showEvents && 
+                <EventsTab events={events} />
+              }
               {showMembers && (
                 <MembersTab memberIds={memberIds} memberRoles={memberRoles} />
               )}

--- a/src/pages/CommunitiProfile/CommunitiProfile.jsx
+++ b/src/pages/CommunitiProfile/CommunitiProfile.jsx
@@ -1,6 +1,6 @@
 import "./CommunitiProfile.scss";
 import { useState, useEffect } from "react";
-import DashboardNavbar from "../../components/DashboardNavbar/DashboardNavbar";
+// import DashboardNavbar from "../../components/DashboardNavbar/DashboardNavbar";
 import penAndPaper from "../../assets/images/penAndPaper.svg";
 import location from "../../assets/images/location.svg";
 import members from "../../assets/images/members.svg";
@@ -8,15 +8,16 @@ import AnnouncementsTab from "../../components/AnnouncementsTabPublic/Announceme
 import EventsTab from "../../components/EventsTabPublic/EventsTabPublic";
 import MembersTab from "../../components/MembersTab/MembersTab";
 import { useParams } from "react-router-dom";
-import { db, auth } from "../../Firebase/FirebaseConfig";
-import {
-  collection,
-  doc,
-  getDoc,
-  getDocs,
-  updateDoc,
-  setDoc,
-} from "firebase/firestore";
+// import { db, auth } from "../../Firebase/FirebaseConfig";
+// import {
+//   collection,
+//   doc,
+//   getDoc,
+//   getDocs,
+//   updateDoc,
+//   setDoc,
+// } from "firebase/firestore";
+import data from "../../data.json";
 
 function CommunitiProfile() {
   const { id } = useParams();
@@ -32,60 +33,74 @@ function CommunitiProfile() {
   const [isUserJoined, setIsUserJoined] = useState(false); // Define isUserJoined state
 
   useEffect(() => {
-    const fetchCommunityData = async () => {
-      try {
-        if (id) {
-          const communityRef = doc(collection(db, "Communities"), id);
-          const communityDoc = await getDoc(communityRef);
+    let community = data.communities.filter(c => {return c.id === communityId})[0];
+    setCommunityData(community);
+    setAnnouncements(community.announcements || []);
+    setEvents(community.events || []);
+  },[]);
+  console.log(communityInfo);
 
-          if (communityDoc.exists()) {
-            const community = communityDoc.data();
-            setCommunityData(community);
-            setAnnouncements(community.announcements || []);
-            setEvents(community.events || []);
+  // useEffect(() => {
+  //   const fetchCommunityData = async () => {
+  //     try {
+  //       if (id) {
+  //         const communityRef = doc(collection(db, "Communities"), id);
+  //         const communityDoc = await getDoc(communityRef);
 
-            const membersCollectionRef = collection(
-              db,
-              `Communities/${id}/Members`
-            );
-            const membersSnapshot = await getDocs(membersCollectionRef);
-            const memberIds = membersSnapshot.docs.map((doc) => doc.id);
-            setMemberIds(memberIds);
-            setMemberCount(memberIds.length);
+  //         if (communityDoc.exists()) {
+  //           const community = communityDoc.data();
+  //           setCommunityData(community);
+  //           setAnnouncements(community.announcements || []);
+  //           setEvents(community.events || []);
 
-            const memberRoles = [];
-            for (const memberId of memberIds) {
-              const memberRef = doc(
-                collection(db, `Communities/${id}/Members`),
-                memberId
-              );
-              const memberDoc = await getDoc(memberRef);
-              if (memberDoc.exists()) {
-                const memberData = memberDoc.data();
-                const memberRole = {
-                  memberId,
-                  role: memberData.role || "Default Role",
-                };
-                memberRoles.push(memberRole);
-              }
-            }
-            setMemberRoles(memberRoles);
-          } else {
-            console.log("No such document!");
-          }
-        }
-      } catch (error) {
-        console.error("Error fetching document: ", error);
-      }
-    };
+  //           const membersCollectionRef = collection(
+  //             db,
+  //             `Communities/${id}/Members`
+  //           );
+  //           const membersSnapshot = await getDocs(membersCollectionRef);
+  //           const memberIds = membersSnapshot.docs.map((doc) => doc.id);
+  //           setMemberIds(memberIds);
+  //           setMemberCount(memberIds.length);
 
-    fetchCommunityData();
-  }, [id]);
+  //           const memberRoles = [];
+  //           for (const memberId of memberIds) {
+  //             const memberRef = doc(
+  //               collection(db, `Communities/${id}/Members`),
+  //               memberId
+  //             );
+  //             const memberDoc = await getDoc(memberRef);
+  //             if (memberDoc.exists()) {
+  //               const memberData = memberDoc.data();
+  //               const memberRole = {
+  //                 memberId,
+  //                 role: memberData.role || "Default Role",
+  //               };
+  //               memberRoles.push(memberRole);
+  //             }
+  //           }
+  //           setMemberRoles(memberRoles);
+  //         } else {
+  //           console.log("No such document!");
+  //         }
+  //       }
+  //     } catch (error) {
+  //       console.error("Error fetching document: ", error);
+  //     }
+  //   };
+
+  //   fetchCommunityData();
+  // }, [id]);
 
   useEffect(() => {
     const currentUser = auth.currentUser;
     if (currentUser) {
       const userId = currentUser.uid;
+
+
+      // Dummy data insert
+      userId = data.users[0].uid;
+
+
       setIsUserJoined(memberIds.includes(userId)); // Set the user's membership status
     }
   }, [memberIds]); // Update isUserJoined when memberIds change
@@ -147,7 +162,7 @@ function CommunitiProfile() {
 
   return (
     <>
-      <DashboardNavbar />
+      {/* <DashboardNavbar /> */}
       <main className="communiti-profile">
         <section className="communiti-profile__hero">
           {!isUserJoined && ( // Render the button only if the user hasn't joined

--- a/src/pages/EventsPage/EventsPage.jsx
+++ b/src/pages/EventsPage/EventsPage.jsx
@@ -1,42 +1,55 @@
-import EventsNavbar from "../../components/DashboardNavbar/DashboardNavbar";
+// import EventsNavbar from "../../components/DashboardNavbar/DashboardNavbar";
 import "./EventsPage.scss";
 import { collection, doc, getDoc } from "firebase/firestore";
 import EventsInfo from "../../components/EventsInfo/EventsInfo";
 import EventsInfoPublic from "../../components/EventsInfoPublic/EventsInfo";
 import { useState, useEffect } from "react";
 import { db, auth } from "../../Firebase/FirebaseConfig";
+import data from "../../data.json";
 
 function EventsHomePage() {
   const [userCommunitiesJoined, setUserCommunitiesJoined] = useState([]);
   const [userCommunitiesManaged, setUserCommunitiesManaged] = useState([]);
   const [selectedOption, setSelectedOption] = useState("option1"); // Default to All Events
 
+  console.log(data.events)
+
+  // useEffect(() => {
+  //   // Fetch user's communities
+  //   const fetchUserCommunities = async () => {
+  //     try {
+  //       const currentUser = auth.currentUser;
+  //       if (currentUser) {
+  //         const uid = currentUser.uid;
+  //         const userDocRef = doc(collection(db, "Users"), uid);
+  //         const userDocSnapshot = await getDoc(userDocRef);
+
+  //         if (userDocSnapshot.exists()) {
+  //           const userData = userDocSnapshot.data();
+  //           const joinedIds = userData.CommunitiesJoined || [];
+  //           const managedIds = userData.CommunitiesManage || [];
+
+  //           setUserCommunitiesJoined(joinedIds);
+  //           setUserCommunitiesManaged(managedIds);
+  //         }
+  //       }
+  //     } catch (error) {
+  //       console.error("Error fetching user communities:", error);
+  //     }
+  //   };
+
+  //   fetchUserCommunities();
+  // }, []);
+
   useEffect(() => {
-    // Fetch user's communities
-    const fetchUserCommunities = async () => {
-      try {
-        const currentUser = auth.currentUser;
-        if (currentUser) {
-          const uid = currentUser.uid;
-          const userDocRef = doc(collection(db, "Users"), uid);
-          const userDocSnapshot = await getDoc(userDocRef);
-
-          if (userDocSnapshot.exists()) {
-            const userData = userDocSnapshot.data();
-            const joinedIds = userData.CommunitiesJoined || [];
-            const managedIds = userData.CommunitiesManage || [];
-
-            setUserCommunitiesJoined(joinedIds);
-            setUserCommunitiesManaged(managedIds);
-          }
-        }
-      } catch (error) {
-        console.error("Error fetching user communities:", error);
-      }
-    };
-
-    fetchUserCommunities();
+    setUserCommunitiesJoined(data.users[0].communitiesJoined);
   }, []);
+  useEffect(() => {
+    setUserCommunitiesManaged(data.users[0].communitiesManaged);
+  }, []);
+
+  console.log(userCommunitiesJoined);
+  console.log(userCommunitiesManaged);
 
   const handleDropdownChange = (event) => {
     setSelectedOption(event.target.value);
@@ -89,7 +102,8 @@ function EventsHomePage() {
 
   return (
     <div className="event-page">
-      <EventsNavbar />
+      <p>{userCommunitiesJoined}</p>
+      {/* <EventsNavbar /> */}
       <div className="event-page__container">
         <div className="event-page__filters">
           <select


### PR DESCRIPTION
## Describe your changes
- Commented out calls to Firebase and temporarily replaced with dummy data JSON file until backend team has completed their APIs
- In EventsTab/EventsTabPublic, replaced the Events component with EventsInfo/EventsInfoPublic (which is used on the main events page)
- Added background color and border styles to EventsTabPublic.scss to match EventsTab.scss
### Note:
- The AdminCommunitiProfile page imports the EventsTab component, which imports the EventsInfo component. Preview with dummy data: http://localhost:3000/communities/admin/0
- The CommunitiProfile page imports the EventsTabPublic component, which imports the EventsInfoPublic component. Preview with dummy data: http://localhost:3000/communities/0
## Issue ticket number and link
[CL2-63 Make events created populate under events tabs of the specific community created by the community manager](https://makeitmvp.atlassian.net/browse/CL2-63?atlOrigin=eyJpIjoiN2RlMmJkZGVhOTFhNGY3NTlkZTc3Nzg5YjJkMzhlYjgiLCJwIjoiaiJ9) (subtask of [CL2-57](https://makeitmvp.atlassian.net/browse/CL2-57?atlOrigin=eyJpIjoiMDAxNjM1OWI3ZDc2NDc2ZGExODczNTAxNWExZDFhMTMiLCJwIjoiaiJ9))
## Checklist before requesting a review
- [x] I have performed a self-review of my code