### PR TITLE
Shortened the timezone dropdown

### DIFF
--- a/src/components/CreateEventModal/CreateEventModal.jsx
+++ b/src/components/CreateEventModal/CreateEventModal.jsx
@@ -49,14 +49,21 @@ function CreateEventModal({ setEventsOverlay, communityData }) {
 
   useEffect(() => {
     // Generate time zone options dynamically
-    const generateTimeZoneOptions = () => {
-      const timeZones = moment.tz.names();
-      const timeZoneOptions = timeZones.map((tz) => ({
-        value: tz,
-        label: `${tz} (UTC${moment.tz(tz).format("Z")})`,
-      }));
-      return timeZoneOptions;
-    };
+ const generateTimeZoneOptions = () => {
+   const majorAmericanTimeZones = [
+     "America/New_York", // Eastern Time
+     "America/Chicago", // Central Time
+     "America/Denver", // Mountain Time
+     "America/Los_Angeles", // Pacific Time
+   ];
+
+   const timeZoneOptions = majorAmericanTimeZones.map((tz) => ({
+     value: tz,
+     label: `${tz} (UTC${moment.tz(tz).format("Z")})`,
+   }));
+
+   return timeZoneOptions;
+ };
 
     // Set the time zone options in state
     setTimezoneOptions(generateTimeZoneOptions());


### PR DESCRIPTION
## Describe your changes
- shortens the timezone options in the dropdown of the form in the createeventmodal to only the major timezones in America

## Issue ticket number and link
[CL2-43 As a development team, we want run QA on our application so that we can identify problems and bugs](https://makeitmvp.atlassian.net/browse/CL2-43)
## Checklist before requesting a review
- [x] I have performed a self-review of my code